### PR TITLE
show packet loss in bps instead of whole percents

### DIFF
--- a/src/WinMTRDialog.cpp
+++ b/src/WinMTRDialog.cpp
@@ -593,26 +593,26 @@ void WinMTRDialog::OnCTTC()
 	
 	int nh = wmtrnet->GetMax();
 	
-	strcpy(f_buf,  "|------------------------------------------------------------------------------------------|\r\n");
-	sprintf(t_buf, "|                                      WinMTR statistics                                   |\r\n");
+	strcpy(f_buf,  "|--------------------------------------------------------------------------------------------|\r\n");
+	sprintf(t_buf, "|                                       WinMTR statistics                                    |\r\n");
 	strcat(f_buf, t_buf);
-	sprintf(t_buf, "|                       Host              -   %%  | Sent | Recv | Best | Avrg | Wrst | Last |\r\n");
+	sprintf(t_buf, "|                       Host              -     %%  | Sent | Recv | Best | Avrg | Wrst | Last |\r\n");
 	strcat(f_buf, t_buf);
-	sprintf(t_buf, "|------------------------------------------------|------|------|------|------|------|------|\r\n");
+	sprintf(t_buf, "|--------------------------------------------------|------|------|------|------|------|------|\r\n");
 	strcat(f_buf, t_buf);
 	
 	for(int i=0; i <nh ; i++) {
 		wmtrnet->GetName(i, buf);
 		if(strcmp(buf,"")==0) strcpy(buf,"No response from host");
 		
-		sprintf(t_buf, "|%40s - %4d | %4d | %4d | %4d | %4d | %4d | %4d |\r\n" ,
+		sprintf(t_buf, "|%40s - %6.2f | %4d | %4d | %4d | %4d | %4d | %4d |\r\n" ,
 				buf, wmtrnet->GetPercent(i),
 				wmtrnet->GetXmit(i), wmtrnet->GetReturned(i), wmtrnet->GetBest(i),
 				wmtrnet->GetAvg(i), wmtrnet->GetWorst(i), wmtrnet->GetLast(i));
 		strcat(f_buf, t_buf);
 	}
 	
-	sprintf(t_buf, "|________________________________________________|______|______|______|______|______|______|\r\n");
+	sprintf(t_buf, "|__________________________________________________|______|______|______|______|______|______|\r\n");
 	strcat(f_buf, t_buf);
 	
 	CString cs_tmp((LPCSTR)IDS_STRING_SB_NAME);
@@ -662,7 +662,7 @@ void WinMTRDialog::OnCHTC()
 		wmtrnet->GetName(i, buf);
 		if(strcmp(buf,"")==0) strcpy(buf,"No response from host");
 		
-		sprintf(t_buf, "<tr><td>%s</td> <td>%4d</td> <td>%4d</td> <td>%4d</td> <td>%4d</td> <td>%4d</td> <td>%4d</td> <td>%4d</td></tr>\r\n" ,
+		sprintf(t_buf, "<tr><td>%s</td> <td>%6.2f</td> <td>%4d</td> <td>%4d</td> <td>%4d</td> <td>%4d</td> <td>%4d</td> <td>%4d</td></tr>\r\n" ,
 				buf, wmtrnet->GetPercent(i),
 				wmtrnet->GetXmit(i), wmtrnet->GetReturned(i), wmtrnet->GetBest(i),
 				wmtrnet->GetAvg(i), wmtrnet->GetWorst(i), wmtrnet->GetLast(i));
@@ -711,26 +711,26 @@ void WinMTRDialog::OnEXPT()
 		
 		int nh = wmtrnet->GetMax();
 		
-		strcpy(f_buf,  "|------------------------------------------------------------------------------------------|\r\n");
-		sprintf(t_buf, "|                                      WinMTR statistics                                   |\r\n");
+		strcpy(f_buf,  "|--------------------------------------------------------------------------------------------|\r\n");
+		sprintf(t_buf, "|                                       WinMTR statistics                                    |\r\n");
 		strcat(f_buf, t_buf);
-		sprintf(t_buf, "|                       Host              -   %%  | Sent | Recv | Best | Avrg | Wrst | Last |\r\n");
+		sprintf(t_buf, "|                       Host              -    %%   | Sent | Recv | Best | Avrg | Wrst | Last |\r\n");
 		strcat(f_buf, t_buf);
-		sprintf(t_buf, "|------------------------------------------------|------|------|------|------|------|------|\r\n");
+		sprintf(t_buf, "|--------------------------------------------------|------|------|------|------|------|------|\r\n");
 		strcat(f_buf, t_buf);
 		
 		for(int i=0; i <nh ; i++) {
 			wmtrnet->GetName(i, buf);
 			if(strcmp(buf,"")==0) strcpy(buf,"No response from host");
 			
-			sprintf(t_buf, "|%40s - %4d | %4d | %4d | %4d | %4d | %4d | %4d |\r\n" ,
+			sprintf(t_buf, "|%40s - %6.2f | %4d | %4d | %4d | %4d | %4d | %4d |\r\n" ,
 					buf, wmtrnet->GetPercent(i),
 					wmtrnet->GetXmit(i), wmtrnet->GetReturned(i), wmtrnet->GetBest(i),
 					wmtrnet->GetAvg(i), wmtrnet->GetWorst(i), wmtrnet->GetLast(i));
 			strcat(f_buf, t_buf);
 		}
 		
-		sprintf(t_buf, "|________________________________________________|______|______|______|______|______|______|\r\n");
+		sprintf(t_buf, "|__________________________________________________|______|______|______|______|______|______|\r\n");
 		strcat(f_buf, t_buf);
 		
 		
@@ -783,7 +783,7 @@ void WinMTRDialog::OnEXPH()
 			wmtrnet->GetName(i, buf);
 			if(strcmp(buf,"")==0) strcpy(buf,"No response from host");
 			
-			sprintf(t_buf, "<tr><td>%s</td> <td>%4d</td> <td>%4d</td> <td>%4d</td> <td>%4d</td> <td>%4d</td> <td>%4d</td> <td>%4d</td></tr>\r\n" ,
+			sprintf(t_buf, "<tr><td>%s</td> <td>%6.2f</td> <td%4d</td> <td>%4d</td> <td>%4d</td> <td>%4d</td> <td>%4d</td> <td>%4d</td></tr>\r\n" ,
 					buf, wmtrnet->GetPercent(i),
 					wmtrnet->GetXmit(i), wmtrnet->GetReturned(i), wmtrnet->GetBest(i),
 					wmtrnet->GetAvg(i), wmtrnet->GetWorst(i), wmtrnet->GetLast(i));
@@ -838,7 +838,7 @@ int WinMTRDialog::DisplayRedraw()
 			
 		m_listMTR.SetItem(i, 1, LVIF_TEXT, nr_crt, 0, 0, 0, 0);
 		
-		sprintf(buf, "%d", wmtrnet->GetPercent(i));
+		sprintf(buf, "%6.2f", wmtrnet->GetPercent(i));
 		m_listMTR.SetItem(i, 2, LVIF_TEXT, buf, 0, 0, 0, 0);
 		
 		sprintf(buf, "%d", wmtrnet->GetXmit(i));

--- a/src/WinMTRNet.cpp
+++ b/src/WinMTRNet.cpp
@@ -336,10 +336,10 @@ int WinMTRNet::GetAvg(int at)
 	return ret;
 }
 
-int WinMTRNet::GetPercent(int at)
+double WinMTRNet::GetPercent(int at)
 {
 	WaitForSingleObject(ghMutex, INFINITE);
-	int ret = (host[at].xmit == 0) ? 0 : (100 - (100 * host[at].returned / host[at].xmit));
+	double ret = (host[at].xmit == 0) ? 0 : (100 - (100.0 * host[at].returned / host[at].xmit));
 	ReleaseMutex(ghMutex);
 	return ret;
 }

--- a/src/WinMTRNet.h
+++ b/src/WinMTRNet.h
@@ -70,7 +70,7 @@ public:
 	int		GetBest(int at);
 	int		GetWorst(int at);
 	int		GetAvg(int at);
-	int		GetPercent(int at);
+	double	GetPercent(int at);
 	int		GetLast(int at);
 	int		GetReturned(int at);
 	int		GetXmit(int at);

--- a/src/WinMTRProperties.cpp
+++ b/src/WinMTRProperties.cpp
@@ -70,7 +70,7 @@ BOOL WinMTRProperties::OnInitDialog()
 	m_editHost.SetWindowText(host);
 	m_editComment.SetWindowText(comment);
 
-	sprintf(buf, "%d", pck_loss);
+	sprintf(buf, "%6.2f", pck_loss);
 	m_editLoss.SetWindowText(buf);
 	sprintf(buf, "%d", pck_sent);
 	m_editSent.SetWindowText(buf);

--- a/src/WinMTRProperties.h
+++ b/src/WinMTRProperties.h
@@ -40,7 +40,7 @@ public:
 
 	int		pck_sent;
 	int		pck_recv;
-	int		pck_loss;
+	double	pck_loss;
 
 	CEdit	m_editHost,
 			m_editIP,


### PR DESCRIPTION
As little as 0.5% packet loss is very high for many links, and will cause a degraded internet experience. So it's important to be able to see precise loss rates. This shows them in bps (hundredths of a percent) instead of whole percents.